### PR TITLE
make docker image usable with non-root users by adding capabilities to binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ RUN apk add --no-cache \
     # for the firewall
     nftables ipset iptables \
     # for templating
-    envsubst
+    envsubst \
+    # for capabilities
+    libcap-setcap
 
 # Install the firewall
 RUN wget -qO - \
@@ -16,6 +18,13 @@ RUN wget -qO - \
     | tar -xz -C /tmp/ \
     && mv /tmp/crowdsec-firewall-bouncer*/crowdsec-firewall-bouncer /usr/local/bin/crowdsec-firewall-bouncer \
     && chmod +x /usr/local/bin/crowdsec-firewall-bouncer
+
+# Apply capabilities to the ACTUAL binaries, not the symlinks
+RUN setcap cap_net_admin,cap_net_raw+ep /usr/sbin/xtables-nft-multi && \
+    setcap cap_net_admin,cap_net_raw+ep /usr/sbin/ipset
+
+# needed so non-root user can create xtables lock file
+RUN chmod o+w /run
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN setcap cap_net_admin,cap_net_raw+ep /usr/sbin/xtables-nft-multi && \
     setcap cap_net_admin,cap_net_raw+ep /usr/sbin/ipset
 
 # needed so non-root user can create xtables lock file
-RUN chmod o+w /run
+RUN chmod 1777 /run
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
by adding the file capabilities, also non-root users will be able to modify iptables (when having the needed capabilties). This makes it possible to run the container as non-root user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced container deployment configuration to grant necessary network capabilities to relevant binaries, enable non-root network operations, and adjust runtime directory permissions so processes can create required lock files; includes minor documentation clarifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->